### PR TITLE
Fixed 'handlebars' typo in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bootprint-base": "<1.0.0"
   },
   "files": [
-    "handlebasr",
+    "handlebars",
     "less",
     "index.js"
   ]


### PR DESCRIPTION
Looks like there was a typo in the packages.json file in the last release (0.8.2). 
Changed 'handlebasr' to 'handlebars'.
