### PR TITLE
Fix pattern display

### DIFF
--- a/handlebars/partials/json-schema/datatype.hbs
+++ b/handlebars/partials/json-schema/datatype.hbs
@@ -65,5 +65,5 @@
     {{/if}}
 {{/if}}
 {{#if pattern}}
-    <span class="json-property-pattern" title="String pattern">, must match <span class="json-schema--regex">{{pattern}}</span>
+    <span class="json-property-pattern" title="String pattern">, must match <span class="json-schema--regex">{{pattern}}</span></span>
 {{/if}}

--- a/less/theme.less
+++ b/less/theme.less
@@ -110,6 +110,7 @@
     color: lighten(@text-color, 30%);
     content: '/';
   }
+  &:extend(code);
 }
 
 .json-property-type {


### PR DESCRIPTION
I noticed the `<span>` tag that surrounds `json-schema--regex` was missing its closing tag, so I've added the closing tag.

Additionally, this PR extends the styles for `<code>`, applying them to the `json-schema--regex` class.