### PR TITLE
Support type property as an array, according to JSON Schema Validation

### DIFF
--- a/handlebars/helpers.js
+++ b/handlebars/helpers.js
@@ -101,5 +101,16 @@ function dataType (value) {
   if (value.type === 'array') {
     return dataType(value.items || {}) + '[]'
   }
+  if (Array.isArray(value.type)) {
+    var types = ''
+    value.type.forEach(function (element) {
+      var subType = {}
+      subType.type = element
+      subType.items = value.items || {}
+      if (types) types += '|'
+      types += dataType(subType)
+    })
+    if (types) return types
+  }
   return value.type
 }

--- a/handlebars/partials/json-schema/body.hbs
+++ b/handlebars/partials/json-schema/body.hbs
@@ -18,11 +18,11 @@
     {{#ifeq type 'object'}}
         {{>json-schema/type-object}}
     {{else}}
-        {{#ifeq type 'array'}}
+        {{#ifcontains type 'array'}}
             {{#if items}}
                 {{>json-schema/array-items items}}
             {{/if}}
-        {{/ifeq}}
+        {{/ifcontains}}
     {{/ifeq}}
 {{else}}
     {{>json-schema/type-object}}


### PR DESCRIPTION
In JSON Schema, the ["type" property](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.21) may be a string or an array of strings. Previously, if type was set as array of strings (i.e., `"type": ["null", "array"]`), then bootprint-json-schema would render the following:

    null,array

Additionally, the "items" property was not rendered.

The expected result for the given scenario is:

    null, integer[]

And the "items" property should be rendered with its schema definition.

This supports the JSON Schema "type" as it is defined to allow an array of strings. If one of the strings in that array is "array," then `items.type` is used to render the datatype, and the "items" property is also rendered.